### PR TITLE
Use UtcTimezone class from Debian packages

### DIFF
--- a/suds_passworddigest/tests.py
+++ b/suds_passworddigest/tests.py
@@ -1,7 +1,6 @@
 import unittest
 import base64
 
-from suds.sax.date import DateTime, UTC
 from suds_passworddigest.token import UsernameDigestToken
 
 class SudsTest(unittest.TestCase):

--- a/suds_passworddigest/token.py
+++ b/suds_passworddigest/token.py
@@ -5,7 +5,14 @@ import hashlib
 from time import time, strftime, gmtime
 
 from suds.sax.element import Element
-from suds.sax.date import UTC
+
+try:
+    from suds.sax.date import UtcTimezone
+    is_debian_based = True
+except ImportError:
+    from suds.sax.date import UTC
+    is_debian_based = False
+
 from suds.wsse import UsernameToken, wssens, wsuns
 
 
@@ -19,7 +26,10 @@ class UsernameDigestToken(UsernameToken):
 
     def setcreated(self, *args, **kwargs):
         UsernameToken.setcreated(self, *args, **kwargs)
-        self.created = str(UTC(self.created))
+        if is_debian_based:
+            self.created = str(self.created.replace(tzinfo=UtcTimezone()))
+        else:
+            self.created = str(UTC(self.created))
 
     def reset(self):
         self.nonce = None


### PR DESCRIPTION
Hello,

There's some issue with SUDS timezone handling and Debian replaced the UTC function by UtcTimezone class to provide a way out.

Here is the upstream bug/discussion related to this topic:
https://fedorahosted.org/suds/ticket/353

This pull request tries to import the Debian new classes and use them, otherwise fall back to the original code.
